### PR TITLE
rules: fix HTTPS variable not set for some servers

### DIFF
--- a/app/Http/Controllers/Client/ClientController.php
+++ b/app/Http/Controllers/Client/ClientController.php
@@ -124,7 +124,7 @@ class ClientController extends Controller
 
         // Subscription link
         $subsURL = 'http';
-        if ($_SERVER['HTTPS'] == 'on') {
+        if (isset( $_SERVER['HTTPS'] ) && strtolower( $_SERVER['HTTPS'] ) == 'on') {
             $subsURL .= 's';
         }
         $subsURL .= '://';


### PR DESCRIPTION
Fixes:

"exception":"[object] (ErrorException(code: 0): Undefined index: HTTPS at xxx