### PR TITLE
add: added "sni" field for Trojan Link

### DIFF
--- a/app/Utils/Helper.php
+++ b/app/Utils/Helper.php
@@ -62,7 +62,8 @@ class Helper
         $server->name = rawurlencode($server->name);
         $query = http_build_query([
             'allowInsecure' => $server->allow_insecure,
-            'peer' => $server->server_name
+            'peer' => $server->server_name,
+            'sni' => $server->server_name
         ]);
         $uri = "trojan://{$user->uuid}@{$server->host}:{$server->port}?{$query}#{$server->name}";
         $uri .= "\r\n";


### PR DESCRIPTION
Server Name Indication is a TLS extension currently mentioned in [RFC6066](https://tools.ietf.org/html/rfc6066)
The abbreviation is SNI, not "peer"

This PR added "sni" field in `BuildTrojanLink` function, to keep the backward compatibility, the "peer" is kept.

Since URLQuery is not order-dependent and key-name-dependent, adding more items should not break current parser implementations.