### PR TITLE
修复易支付"支付结果通知"回调

### DIFF
--- a/app/Http/Routes/GuestRoute.php
+++ b/app/Http/Routes/GuestRoute.php
@@ -17,7 +17,7 @@ class GuestRoute
             $router->post('/order/stripeNotify', 'Guest\\OrderController@stripeNotify');
             $router->post('/order/bitpayXNotify', 'Guest\\OrderController@bitpayXNotify');
             $router->post('/order/mgateNotify', 'Guest\\OrderController@mgateNotify');
-            $router->post('/order/epayNotify', 'Guest\\OrderController@epayNotify');
+            $router->get('/order/epayNotify', 'Guest\\OrderController@epayNotify');
             // Telegram
             $router->post('/telegram/webhook', 'Guest\\TelegramController@webhook');
         });


### PR DESCRIPTION
很惭愧，只做了一点微小的贡献
易支付SDK里支付结果通知api使用的是GET方法
改完这个 v2board就可以正常显示支付结果了