### PR TITLE
grpc功能完善

### DIFF
--- a/app/Http/Controllers/Client/ClientController.php
+++ b/app/Http/Controllers/Client/ClientController.php
@@ -32,6 +32,24 @@ class ClientController extends Controller
             $serverService = new ServerService();
             $servers = $serverService->getAvailableServers($user);
             if ($flag) {
+                $ua_list=array("Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.3; Trident/7.0; .NET4.0E; .NET4.0C)",
+                    "Mozilla/5.0 (compatible; WOW64; MSIE 10.0; Windows NT 6.2)",
+                    "Mozilla/5.0 (iPad; CPU OS 5_0 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.1 Mobile/9A334 Safari/7534.48.3",
+                    "Mozilla/5.0 (iPhone; CPU iPhone OS 5_0 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.1 Mobile/9A334 Safari/7534.48.3",
+                    "Mozilla/5.0 (Linux; Android 4.4; Nexus 5 Build/BuildID) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36",
+                    "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36",
+                    "Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko",
+                    "Mozilla/5.0 (Windows NT 6.3; WOW64; rv:40.0) Gecko/20100101 Firefox/40.0",
+                    "Mozilla/5.0 (Windows NT 6.3; WOW64; rv:40.0) Gecko/20100101 Firefox/44.0",
+                    "Mozilla/5.0 (Windows; U; Windows NT 6.1; enUS) AppleWebKit/533.20.25 (KHTML, like Gecko) Version/5.0.4 Safari/533.20.27",
+                    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/535.11 (KHTML, like Gecko) Ubuntu/11.10 Chromium/27.0.1453.93 Chrome/27.0.1453.93 Safari/537.36",
+                    "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:35.0) Gecko/20100101 Firefox/35.0");
+                foreach ($ua_list as $ua){
+                    if(strcasecmp($flag,"$ua")==0){
+                        die($this->shadowrocket($user, $servers));
+                        break;
+                    }
+                }
                 if (strpos($flag, 'quantumult%20x') !== false) {
                     die($this->quantumultX($user, $servers));
                 }

--- a/app/Services/ServerService.php
+++ b/app/Services/ServerService.php
@@ -176,6 +176,7 @@ class ServerService
 
     private function setNetwork(Server $server, object $json)
     {
+
         if ($server->networkSettings) {
             switch ($server->network) {
                 case 'tcp':
@@ -195,6 +196,9 @@ class ServerService
                     break;
                 case 'quic':
                     $json->inbound->streamSettings->quicSettings = json_decode($server->networkSettings);
+                    break;
+                case 'grpc':
+                    $json->inbound->streamSettings->grpcSettings = json_decode($server->networkSettings);
                     break;
             }
         }
@@ -242,21 +246,23 @@ class ServerService
 
     private function setTls(Server $server, object $json)
     {
-        if ((int)$server->tls) {
-            $tlsSettings = json_decode($server->tlsSettings);
-            $json->inbound->streamSettings->security = 'tls';
-            $tls = (object)[
-                'certificateFile' => '/root/.cert/server.crt',
-                'keyFile' => '/root/.cert/server.key'
-            ];
-            $json->inbound->streamSettings->tlsSettings = new \StdClass();
-            if (isset($tlsSettings->serverName)) {
-                $json->inbound->streamSettings->tlsSettings->serverName = (string)$tlsSettings->serverName;
+        if ((int)$server->nodeTls) {
+            if ((int)$server->tls) {
+                $tlsSettings = json_decode($server->tlsSettings);
+                $json->inbound->streamSettings->security = 'tls';
+                $tls = (object)[
+                    'certificateFile' => '/root/.cert/server.crt',
+                    'keyFile' => '/root/.cert/server.key'
+                ];
+                $json->inbound->streamSettings->tlsSettings = new \StdClass();
+                if (isset($tlsSettings->serverName)) {
+                    $json->inbound->streamSettings->tlsSettings->serverName = (string)$tlsSettings->serverName;
+                }
+                if (isset($tlsSettings->allowInsecure)) {
+                    $json->inbound->streamSettings->tlsSettings->allowInsecure = (int)$tlsSettings->allowInsecure ? true : false;
+                }
+                $json->inbound->streamSettings->tlsSettings->certificates[0] = $tls;
             }
-            if (isset($tlsSettings->allowInsecure)) {
-                $json->inbound->streamSettings->tlsSettings->allowInsecure = (int)$tlsSettings->allowInsecure ? true : false;
-            }
-            $json->inbound->streamSettings->tlsSettings->certificates[0] = $tls;
         }
     }
 

--- a/app/Utils/Shadowrocket.php
+++ b/app/Utils/Shadowrocket.php
@@ -47,13 +47,13 @@ class Shadowrocket
         if ($server['network'] === 'grpc') {
             $config['obfs'] = "grpc";
             if (isset($server['networkSettings'])) {
-                $grpcObject = json_decode($server['networkSettings'], true);
-                if (isset($grpcObject['serviceName'])) {
-                    $config['obfsParam'] = json_decode([
-                        'Host' => $grpcObject['serviceName']
-                    ]);
-                    $config['path'] = '/';
-                }
+                $grpcSettings = json_decode($server['networkSettings'], true);
+                if (isset($grpcSettings['serviceName']) && !empty($grpcSettings['serviceName']))
+                    $config['path'] = $grpcSettings['serviceName'];
+                if (isset($grpcSettings['host']) && !empty($grpcSettings['host']))
+                    $config['obfsParam'] = $grpcSettings['host'];
+                if (!isset($grpcSettings['host']) && !empty($tlsSettings['serverName']))
+                    $config['obfsParam'] = $tlsSettings['serverName'];
             }
         }
         $query = http_build_query($config, '', '&', PHP_QUERY_RFC3986);

--- a/app/Utils/URLSchemes.php
+++ b/app/Utils/URLSchemes.php
@@ -43,12 +43,17 @@ class URLSchemes
             "type" => "none",
             "host" => "",
             "path" => "",
-            "tls" => $server['tls'] ? "tls" : ""
+            "tls" => $server['tls'] ? "tls" : "",
+            "sni" => $server['tls'] ? json_decode($server['tlsSettings'], true)['serverName'] : ""
         ];
         if ((string)$server['network'] === 'ws') {
             $wsSettings = json_decode($server['networkSettings'], true);
             if (isset($wsSettings['path'])) $config['path'] = $wsSettings['path'];
             if (isset($wsSettings['headers']['Host'])) $config['host'] = $wsSettings['headers']['Host'];
+        }
+        if ((string)$server['network'] === 'grpc') {
+            $grpcSettings = json_decode($server['networkSettings'], true);
+            if (isset($grpcSettings['path'])) $config['path'] = $grpcSettings['serviceName'];
         }
         return "vmess://" . base64_encode(json_encode($config)) . "\r\n";
     }


### PR DESCRIPTION
1、修复Shadowrocket的GPRC协议兼容性
2、修复服务端获取GRPC配置异常
3、修复通用协议缺少sni字段
4、兼容通用协议GRPC（目前支持解析通用协议的客户端较少，常见的路由器固件都支持）
5、其他关于TLS前置，小火箭UA头个人习惯，请忽略