### PR TITLE
fix issue with surge subscribe

### DIFF
--- a/app/Http/Controllers/Client/Protocols/Surge.php
+++ b/app/Http/Controllers/Client/Protocols/Surge.php
@@ -52,8 +52,8 @@ class Surge
         }
 
         // Subscription link
-        $subsURL = config('v2board.subscribe_url', config('v2board.app_url', env('APP_URL'))) . '/api/v1/client/subscribe?token=' . $user['token'];
         $subsDomain = $_SERVER['SERVER_NAME'];
+        $subsURL = 'https://' . $subsDomain . '/api/v1/client/subscribe?token=' . $user['token'];
 
         $config = str_replace('$subs_link', $subsURL, $config);
         $config = str_replace('$subs_domain', $subsDomain, $config);


### PR DESCRIPTION
当前版本的V2Board在面板中配置了多个`订阅URL`时，如：
```
https://a.com, https://b.com, https://c.com
```
通过面板`复制订阅地址`并输入到Surge的`Install from URL...`的时候在本地创建的`subscribe.conf`中的订阅托管地址为:
```
#!MANAGED-CONFIG https://a.com,https://b.com,https://c.com/api/v1/client/subscribe?token=1989aaa interval=43200 strict=true
将三个地址重复添加到了配置文件中
```
而非
```
#!MANAGED-CONFIG https://a.com/api/v1/client/subscribe?token=1989aaa interval=43200 strict=true
```
这样会导致Surge无法正常更新订阅的配置文件，通过Surge Dashboard发现请求变为：
![IMG_1617](https://user-images.githubusercontent.com/24599209/145677550-916c59fc-4cfb-43ed-96df-89f12b3dd639.jpg)
修改过后：
![IMG_1618](https://user-images.githubusercontent.com/24599209/145678317-fb4b7cb7-c4be-4179-ac6d-79d058df452b.jpg)

