### PR TITLE
fix exporting surge config file without file name

### DIFF
--- a/app/Http/Controllers/Client/Protocols/Surge.php
+++ b/app/Http/Controllers/Client/Protocols/Surge.php
@@ -21,6 +21,9 @@ class Surge
         $servers = $this->servers;
         $user = $this->user;
 
+        $appName = config('v2board.app_name', 'V2Board');
+        header("content-disposition:attachment;filename*=UTF-8''".rawurlencode($appName).".conf");
+
         $proxies = '';
         $proxyGroup = '';
 


### PR DESCRIPTION
Surge 截止目前的版本，对 utf-8 文件名的支持也是有问题的，已给 surge 方面提交了 bug，对方已回复会尽快修复。