### PR TITLE
修复Stash无法获取订阅

### DIFF
--- a/app/Http/Controllers/Client/Protocols/Stash.php
+++ b/app/Http/Controllers/Client/Protocols/Stash.php
@@ -154,6 +154,11 @@ class Stash
         return $array;
     }
 
+    private function isRegex($exp)
+    {
+        return @preg_match($exp, null) !== false;
+    }
+
     private function isMatch($exp, $str)
     {
         try {


### PR DESCRIPTION
app/Http/Controllers/Client/Protocols/Stash.php缺少isRegex()函数，导致获取配置文件时出错
![image](https://user-images.githubusercontent.com/18487473/191698643-9cf0b0ff-88d3-4b63-9035-23ac3fd48c24.png)
