### PR TITLE
Stripe: add Checkout support & directly show the payments id

### DIFF
--- a/app/Payments/StripeCredit.php
+++ b/app/Payments/StripeCredit.php
@@ -98,11 +98,14 @@ class StripeCredit {
             case 'charge.succeeded':
                 $object = $event->data->object;
                 if ($object->status === 'succeeded') {
+                    if (!isset($object->metadata->out_trade_no) && !isset($object->source->metadata)) {
+                        die('order error');
+                    }
                     $metaData = isset($object->metadata->out_trade_no) ? $object->metadata : $object->source->metadata;
                     $tradeNo = $metaData->out_trade_no;
                     return [
                         'trade_no' => $tradeNo,
-                        'callback_no' => $object->balance_transaction
+                        'callback_no' => $object->id
                     ];
                 }
                 break;

--- a/app/Payments/StripeWepay.php
+++ b/app/Payments/StripeWepay.php
@@ -91,11 +91,14 @@ class StripeWepay {
             case 'charge.succeeded':
                 $object = $event->data->object;
                 if ($object->status === 'succeeded') {
+                    if (!isset($object->metadata->out_trade_no) && !isset($object->source->metadata)) {
+                        die('order error');
+                    }
                     $metaData = isset($object->metadata->out_trade_no) ? $object->metadata : $object->source->metadata;
                     $tradeNo = $metaData->out_trade_no;
                     return [
                         'trade_no' => $tradeNo,
-                        'callback_no' => $object->balance_transaction
+                        'callback_no' => $object->id
                     ];
                 }
                 break;


### PR DESCRIPTION
### Ho-To-Use:

1.1 We need to add a new stripecheckout webhook (aka notify url) on the stripe webhook website page,

`https://your_web_site/api/v1/guest/payment/notify/StripeCheckout/generated_id`

1.2 and add to listen for the following two events: 

`checkout.session.completed` `checkout.session.async_payment_succeeded`

### Notes:

-1- Stripe Checkout does not support metadata, but it will send the `charge.succeeded` to all webhooks that are listening for charge event. So we need to add error responses to the supported gateways, Such as Stripe Alipay. Otherwise there will be show a 500 error.
-2-  It's very painful to find balance_transaction from a bunch of payments, I changed it to payment id, it will be easier to find.
E.g. Charges type payments: py_1LapQ5BiVOEqD4QMNbuiuOt3, PaymentIntents type payments: pi_2Lq61jBiVIQqDS6M85acPsY9