### PR TITLE
Add a subscription information panel

### DIFF
--- a/app/Http/Controllers/Client/Protocols/Surfboard.php
+++ b/app/Http/Controllers/Client/Protocols/Surfboard.php
@@ -64,6 +64,14 @@ class Surfboard
         $config = str_replace('$subs_domain', $subsDomain, $config);
         $config = str_replace('$proxies', $proxies, $config);
         $config = str_replace('$proxy_group', rtrim($proxyGroup, ', '), $config);
+
+        $upload = round($user['u'] / (1024*1024*1024), 2);
+        $download = round($user['d'] / (1024*1024*1024), 2);
+        $totalTraffic = round($user['transfer_enable'] / (1024*1024*1024), 2);
+        $expireDate = $user['expired_at'] === NULL ? '长期有效' : date('Y-m-d H:i:s', $user['expired_at']);
+        $subscribeInfo = "title=\"{$appName}订阅信息\", content=\"上传流量：{$upload}GB\\n下载流量：{$download}GB\\n已用总流量：{$totalTraffic}GB\\n到期时间：{$expireDate}\"";
+        $config = str_replace('$subscribe_info', $subscribeInfo, $config);
+
         return $config;
     }
 

--- a/app/Http/Controllers/Client/Protocols/Surfboard.php
+++ b/app/Http/Controllers/Client/Protocols/Surfboard.php
@@ -69,7 +69,7 @@ class Surfboard
         $download = round($user['d'] / (1024*1024*1024), 2);
         $totalTraffic = round($user['transfer_enable'] / (1024*1024*1024), 2);
         $expireDate = $user['expired_at'] === NULL ? '长期有效' : date('Y-m-d H:i:s', $user['expired_at']);
-        $subscribeInfo = "title=\"{$appName}订阅信息\", content=\"上传流量：{$upload}GB\\n下载流量：{$download}GB\\n已用总流量：{$totalTraffic}GB\\n到期时间：{$expireDate}\"";
+        $subscribeInfo = "title={$appName}订阅信息, content=上传流量：{$upload}GB\\n下载流量：{$download}GB\\n已用总流量：{$totalTraffic}GB\\n到期时间：{$expireDate}";
         $config = str_replace('$subscribe_info', $subscribeInfo, $config);
 
         return $config;

--- a/app/Http/Controllers/Client/Protocols/Surfboard.php
+++ b/app/Http/Controllers/Client/Protocols/Surfboard.php
@@ -67,9 +67,10 @@ class Surfboard
 
         $upload = round($user['u'] / (1024*1024*1024), 2);
         $download = round($user['d'] / (1024*1024*1024), 2);
+        $useTraffic = $upload + $download;
         $totalTraffic = round($user['transfer_enable'] / (1024*1024*1024), 2);
         $expireDate = $user['expired_at'] === NULL ? '长期有效' : date('Y-m-d H:i:s', $user['expired_at']);
-        $subscribeInfo = "title={$appName}订阅信息, content=上传流量：{$upload}GB\\n下载流量：{$download}GB\\n已用总流量：{$totalTraffic}GB\\n到期时间：{$expireDate}";
+        $subscribeInfo = "title={$appName}订阅信息, content=上传流量：{$upload}GB\\n下载流量：{$download}GB\\n剩余流量：{$useTraffic}GB\\n套餐流量：{$totalTraffic}GB\\n到期时间：{$expireDate}";
         $config = str_replace('$subscribe_info', $subscribeInfo, $config);
 
         return $config;

--- a/app/Http/Controllers/Client/Protocols/Surge.php
+++ b/app/Http/Controllers/Client/Protocols/Surge.php
@@ -67,9 +67,10 @@ class Surge
 
         $upload = round($user['u'] / (1024*1024*1024), 2);
         $download = round($user['d'] / (1024*1024*1024), 2);
+        $useTraffic = $upload + $download;
         $totalTraffic = round($user['transfer_enable'] / (1024*1024*1024), 2);
         $expireDate = $user['expired_at'] === NULL ? '长期有效' : date('Y-m-d H:i:s', $user['expired_at']);
-        $subscribeInfo = "title={$appName}订阅信息, content=上传流量：{$upload}GB\\n下载流量：{$download}GB\\n已用总流量：{$totalTraffic}GB\\n到期时间：{$expireDate}";
+        $subscribeInfo = "title={$appName}订阅信息, content=上传流量：{$upload}GB\\n下载流量：{$download}GB\\n剩余流量：{$useTraffic}GB\\n套餐流量：{$totalTraffic}GB\\n到期时间：{$expireDate}";
         $config = str_replace('$subscribe_info', $subscribeInfo, $config);
 
         return $config;

--- a/app/Http/Controllers/Client/Protocols/Surge.php
+++ b/app/Http/Controllers/Client/Protocols/Surge.php
@@ -69,7 +69,7 @@ class Surge
         $download = round($user['d'] / (1024*1024*1024), 2);
         $totalTraffic = round($user['transfer_enable'] / (1024*1024*1024), 2);
         $expireDate = $user['expired_at'] === NULL ? '长期有效' : date('Y-m-d H:i:s', $user['expired_at']);
-        $subscribeInfo = "title=\"{$appName}订阅信息\", content=\"上传流量：{$upload}GB\\n下载流量：{$download}GB\\n已用总流量：{$totalTraffic}GB\\n到期时间：{$expireDate}\"";
+        $subscribeInfo = "title={$appName}订阅信息, content=上传流量：{$upload}GB\\n下载流量：{$download}GB\\n已用总流量：{$totalTraffic}GB\\n到期时间：{$expireDate}";
         $config = str_replace('$subscribe_info', $subscribeInfo, $config);
 
         return $config;

--- a/app/Http/Controllers/Client/Protocols/Surge.php
+++ b/app/Http/Controllers/Client/Protocols/Surge.php
@@ -64,6 +64,14 @@ class Surge
         $config = str_replace('$subs_domain', $subsDomain, $config);
         $config = str_replace('$proxies', $proxies, $config);
         $config = str_replace('$proxy_group', rtrim($proxyGroup, ', '), $config);
+
+        $upload = round($user['u'] / (1024*1024*1024), 2);
+        $download = round($user['d'] / (1024*1024*1024), 2);
+        $totalTraffic = round($user['transfer_enable'] / (1024*1024*1024), 2);
+        $expireDate = $user['expired_at'] === NULL ? '长期有效' : date('Y-m-d H:i:s', $user['expired_at']);
+        $subscribeInfo = "title=\"{$appName}订阅信息\", content=\"上传流量：{$upload}GB\\n下载流量：{$download}GB\\n已用总流量：{$totalTraffic}GB\\n到期时间：{$expireDate}\"";
+        $config = str_replace('$subscribe_info', $subscribeInfo, $config);
+
         return $config;
     }
 

--- a/resources/rules/default.surfboard.conf
+++ b/resources/rules/default.surfboard.conf
@@ -12,6 +12,9 @@ test-timeout = 5
 internet-test-url = http://bing.com
 proxy-test-url = http://bing.com
 
+[Panel]
+SubscribeInfo = $subscribe_info, style=info
+
 # Surfboard 的服务器和策略组配置方式与 Surge 类似, 可以参考 Surge 的规则配置手册: https://manual.nssurge.com/
 
 [Proxy]

--- a/resources/rules/default.surge.conf
+++ b/resources/rules/default.surge.conf
@@ -36,6 +36,9 @@ hide-crashlytics-request = true
 use-keyword-filter = false
 hide-udp = false
 
+[Panel]
+SubscribeInfo = $subscribe_info, style=info
+
 # -----------------------------
 # Surge 的几种策略配置规范，请参考 https://manual.nssurge.com/policy/proxy.html
 # 不同的代理策略有*很多*可选参数，请参考上方连接的 Parameters 一段，根据需求自行添加参数。


### PR DESCRIPTION
Add a subscription information panel to Surge and Surfboard for easy viewing.
If customized the configuration information, you need to add the same configuration to the `custom.surfboard.conf` and `custom.surge.conf`.