### PR TITLE
update: replace redir-host with fake-ip in clash config

### DIFF
--- a/resources/rules/default.clash.yaml
+++ b/resources/rules/default.clash.yaml
@@ -17,8 +17,13 @@ dns:
   default-nameserver:
     - 223.5.5.5
     - 119.29.29.29
-  enhanced-mode: redir-host
+  enhanced-mode: fake-ip
   fake-ip-range: 198.18.0.1/16
+  fake-ip-filter:
+    - '*.lan'
+    - '*.linksys.com'
+    - '+.pool.ntp.org'
+    - localhost.ptlogin2.qq.co
   use-hosts: true
   nameserver:
     - https://doh.pub/dns-query


### PR DESCRIPTION
redir-host confirms that it will be deleted