### PR TITLE
仅cdn开启ssl情况下, laravel 的URL()获取本地域名问题.

### DIFF
--- a/app/Http/Controllers/Admin/ConfigController.php
+++ b/app/Http/Controllers/Admin/ConfigController.php
@@ -56,7 +56,7 @@ class ConfigController extends Controller
 
     public function setTelegramWebhook(Request $request)
     {
-        $hookUrl = url('/api/v1/guest/telegram/webhook?access_token=' . md5(config('v2board.telegram_bot_token', $request->input('telegram_bot_token'))));
+        $hookUrl = url(config('v2board.app_url') . '/api/v1/guest/telegram/webhook?access_token=' . md5(config('v2board.telegram_bot_token', $request->input('telegram_bot_token'))));
         $telegramService = new TelegramService($request->input('telegram_bot_token'));
         $telegramService->getMe();
         $telegramService->setWebhook($hookUrl);


### PR DESCRIPTION
仅cdn设置ssl情况下, 源站未设置ssl, laravel的URl()只能获取到源站http, 导致weebhook不满足https要求