### PR TITLE
update: fix flag name matching confusion

### DIFF
--- a/app/Http/Controllers/Client/Protocols/ClashMeta.php
+++ b/app/Http/Controllers/Client/Protocols/ClashMeta.php
@@ -7,7 +7,7 @@ use Symfony\Component\Yaml\Yaml;
 
 class ClashMeta
 {
-    public $flag = 'clashmeta';
+    public $flag = 'meta';
     private $servers;
     private $user;
 


### PR DESCRIPTION
flag clashmeta will be caught by the clash match, resulting in the desired clashmeta configuration not being output