### PR TITLE
fix: Stripe payment not working

### DIFF
--- a/app/Payments/StripeAlipay.php
+++ b/app/Payments/StripeAlipay.php
@@ -110,8 +110,10 @@ class StripeAlipay {
 
     private function exchange($from, $to)
     {
-        $result = file_get_contents('https://api.exchangerate.host/latest?symbols=' . $to . '&base=' . $from);
+        $from = strtolower($from);
+        $to = strtolower($to);
+        $result = file_get_contents("https://cdn.jsdelivr.net/gh/fawazahmed0/currency-api@1/latest/currencies/" . $from . "/" . $to . ".json");
         $result = json_decode($result, true);
-        return $result['rates'][$to];
+        return $result[$to];
     }
 }

--- a/app/Payments/StripeCheckout.php
+++ b/app/Payments/StripeCheckout.php
@@ -132,8 +132,10 @@ class StripeCheckout {
 
     private function exchange($from, $to)
     {
-        $result = file_get_contents('https://api.exchangerate.host/latest?symbols=' . $to . '&base=' . $from);
+        $from = strtolower($from);
+        $to = strtolower($to);
+        $result = file_get_contents("https://cdn.jsdelivr.net/gh/fawazahmed0/currency-api@1/latest/currencies/" . $from . "/" . $to . ".json");
         $result = json_decode($result, true);
-        return $result['rates'][$to];
+        return $result[$to];
     }
 }

--- a/app/Payments/StripeCredit.php
+++ b/app/Payments/StripeCredit.php
@@ -117,8 +117,10 @@ class StripeCredit {
 
     private function exchange($from, $to)
     {
-        $result = file_get_contents('https://api.exchangerate.host/latest?symbols=' . $to . '&base=' . $from);
+        $from = strtolower($from);
+        $to = strtolower($to);
+        $result = file_get_contents("https://cdn.jsdelivr.net/gh/fawazahmed0/currency-api@1/latest/currencies/" . $from . "/" . $to . ".json");
         $result = json_decode($result, true);
-        return $result['rates'][$to];
+        return $result[$to];
     }
 }

--- a/app/Payments/StripeWepay.php
+++ b/app/Payments/StripeWepay.php
@@ -110,8 +110,10 @@ class StripeWepay {
 
     private function exchange($from, $to)
     {
-        $result = file_get_contents('https://api.exchangerate.host/latest?symbols=' . $to . '&base=' . $from);
+        $from = strtolower($from);
+        $to = strtolower($to);
+        $result = file_get_contents("https://cdn.jsdelivr.net/gh/fawazahmed0/currency-api@1/latest/currencies/" . $from . "/" . $to . ".json");
         $result = json_decode($result, true);
-        return $result['rates'][$to];
+        return $result[$to];
     }
 }


### PR DESCRIPTION
The previous exchange rate conversion API has been tested and is no longer free. It now requires an **API Key**. 

**This PR has been replaced with the currently available free exchange rate conversion API.**