### PR TITLE
feat: add postal mail driver

### DIFF
--- a/app/Http/Requests/Admin/ConfigSave.php
+++ b/app/Http/Requests/Admin/ConfigSave.php
@@ -61,6 +61,8 @@ class ConfigSave extends FormRequest
         'email_password' => '',
         'email_encryption' => '',
         'email_from_address' => '',
+        'email_postal_host' => '',
+        'email_postal_key' => '',
         // telegram
         'telegram_bot_enable' => 'in:0,1',
         'telegram_bot_token' => '',

--- a/app/Jobs/SendEmailJob.php
+++ b/app/Jobs/SendEmailJob.php
@@ -2,6 +2,8 @@
 
 namespace App\Jobs;
 
+use App\Models\MailLog;
+use Exception;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
@@ -9,15 +11,17 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Mail;
-use App\Models\MailLog;
+use Postal\Client;
+use Postal\Send\Message;
 
 class SendEmailJob implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
-    protected $params;
 
     public $tries = 3;
     public $timeout = 10;
+    protected $params;
+
     /**
      * Create a new job instance.
      *
@@ -36,28 +40,50 @@ class SendEmailJob implements ShouldQueue
      */
     public function handle()
     {
+        $driver = "";
         if (config('v2board.email_host')) {
+            $driver = "SMTP";
             Config::set('mail.host', config('v2board.email_host', env('mail.host')));
             Config::set('mail.port', config('v2board.email_port', env('mail.port')));
             Config::set('mail.encryption', config('v2board.email_encryption', env('mail.encryption')));
             Config::set('mail.username', config('v2board.email_username', env('mail.username')));
             Config::set('mail.password', config('v2board.email_password', env('mail.password')));
-            Config::set('mail.from.address', config('v2board.email_from_address', env('mail.from.address')));
-            Config::set('mail.from.name', config('v2board.app_name', 'V2Board'));
+        } elseif (config('v2board.email_postal_host')) {
+            $driver = "Postal";
         }
+        Config::set('mail.from.address', config('v2board.email_from_address', env('mail.from.address')));
+        Config::set('mail.from.name', config('v2board.app_name', 'V2Board'));
         $params = $this->params;
         $email = $params['email'];
         $subject = $params['subject'];
         $params['template_name'] = 'mail.' . config('v2board.email_template', 'default') . '.' . $params['template_name'];
         try {
-            Mail::send(
-                $params['template_name'],
-                $params['template_value'],
-                function ($message) use ($email, $subject) {
-                    $message->to($email)->subject($subject);
-                }
-            );
-        } catch (\Exception $e) {
+            switch ($driver) {
+                case 'SMTP':
+                    Mail::send(
+                        $params['template_name'],
+                        $params['template_value'],
+                        function ($message) use ($email, $subject) {
+                            $message->to($email)->subject($subject);
+                        }
+                    );
+                    break;
+                case 'Postal':
+                    $senderName = Config::get('mail.from.name');
+                    $senderAddress = Config::get('mail.from.address');
+                    $client = new Client(config('v2board.email_postal_host'), config('v2board.email_postal_key'));
+                    $message = new Message();
+                    $message->to($email);
+                    $message->from("$senderName <$senderAddress>");
+                    $message->sender($senderAddress);
+                    $message->subject($subject);
+                    $message->htmlBody(view($params['template_name'], $params['template_value'])->render());
+                    $client->send->message($message);
+                    break;
+                default:
+                    break;
+            }
+        } catch (Exception $e) {
             $error = $e->getMessage();
         }
 
@@ -65,7 +91,7 @@ class SendEmailJob implements ShouldQueue
             'email' => $params['email'],
             'subject' => $params['subject'],
             'template_name' => $params['template_name'],
-            'error' => isset($error) ? $error : NULL
+            'error' => $error ?? NULL
         ];
 
         MailLog::create($log);

--- a/app/Services/ConfigService.php
+++ b/app/Services/ConfigService.php
@@ -68,7 +68,9 @@ class ConfigService {
                 'email_username' => config('v2board.email_username'),
                 'email_password' => config('v2board.email_password'),
                 'email_encryption' => config('v2board.email_encryption'),
-                'email_from_address' => config('v2board.email_from_address')
+                'email_from_address' => config('v2board.email_from_address'),
+                'email_postal_host' => config('v2board.email_postal_host'),
+                'email_postal_key' => config('v2board.email_postal_key'),
             ],
             'telegram' => [
                 'telegram_bot_enable' => config('v2board.telegram_bot_enable', 0),

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "laravel/tinker": "^2.5",
         "linfo/linfo": "^4.0",
         "php-curl-class/php-curl-class": "^8.6",
+        "postal/postal": "^2.0",
         "stripe/stripe-php": "^7.36.1",
         "symfony/yaml": "^4.3",
         "paragonie/sodium_compat": "^1.20"


### PR DESCRIPTION
在后端实现通过Postal API发送邮件，当`email_host`为空且`email_postal_host`不为空时，则切换为Postal发信
前端未添加相关设置，因为没找到源码